### PR TITLE
Add dynamic project info handling via new hook

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,5 @@
-import React, { ComponentProps, useEffect, useMemo } from "react";
-import { useLocation } from "react-router-dom";
+import React, { ComponentProps, useMemo } from "react";
+import {Router, Routes, useLocation} from "react-router-dom";
 import Providers from "@/components/Providers";
 import { isAddress } from "viem";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
@@ -8,12 +8,16 @@ import SwapWidget from "@ensofinance/shortcuts-widget";
 import logoUrl from "./logo_black_white.png";
 
 import "@rainbow-me/rainbowkit/styles.css";
+import useProjectInfo from "@/hooks/useProjectInfo";
 // import "./App.css";
 
 const EnsoApiKey = import.meta.env.VITE_ENSO_API_KEY;
 
 function App() {
   const location = useLocation();
+
+  const projectInfo = useProjectInfo()
+
   const props = useMemo(() => {
     const searchParams = new URLSearchParams(window.location.search);
     const tokenInParam = searchParams.get("tokenIn");
@@ -33,21 +37,6 @@ function App() {
     return props;
   }, [location]);
 
-  useEffect(() => {
-    // Set the title of the page from the environment variable
-    if (import.meta.env.VITE_APP_TITLE) {
-      document.title = `ENSO | ${import.meta.env.VITE_APP_TITLE}`;
-    }
-
-    // Set the favicon of the page from the environment variable
-    if (import.meta.env.VITE_APP_LOGO_URL) {
-      const favicon = document.querySelector("link[rel='icon']");
-      if (favicon instanceof HTMLLinkElement) {
-        favicon.href = import.meta.env.VITE_APP_LOGO_URL;
-      }
-    }
-  }, []);
-
   return (
     <Providers>
       <div
@@ -61,7 +50,7 @@ function App() {
           padding: "5px",
         }}
       >
-        <img src={logoUrl} alt={"Enso"} style={{ height: "50px" }} />
+        <img src={projectInfo?.logo || logoUrl} alt={"Enso"} style={{ height: "50px" }} />
 
         <ConnectButton />
       </div>

--- a/app/src/hooks/useProjectInfo.ts
+++ b/app/src/hooks/useProjectInfo.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+import { FirebaseProjectI } from "@/types/project";
+
+const useProjectInfo = () => {
+  const { pathname } = useLocation();
+  const [projectInfo, setProjectInfo] = useState<FirebaseProjectI | null>(null);
+
+  /**
+   * Updates the document title and favicon dynamically based on project data.
+   * @param title - The title of the project (used in the page title).
+   * @param logo - The URL of the project's favicon.
+   */
+  const setProjectInfoInDOM = (title?: string, logo?: string) => {
+    if (title) {
+      document.title = `ENSO | ${title}`;
+    }
+    if (logo) {
+      let favicon = document.querySelector<HTMLLinkElement>("link[rel='icon']");
+
+      // If favicon does not exist, create a new one
+      if (!favicon) {
+        favicon = document.createElement("link");
+        favicon.rel = "icon";
+        document.head.appendChild(favicon);
+      }
+      favicon.href = logo;
+    }
+  };
+
+  /**
+   * Fetches project data from Firebase using the project name extracted from the URL.
+   * @param slug - The project name derived from the current pathname.
+   */
+  const getProjectData = async (slug: string): Promise<void> => {
+    try {
+      const resp = await fetch(`http://firebase/${slug}`);
+
+      // Check if the response is valid
+      if (!resp.ok) {
+        throw new Error(`Failed to fetch project data: ${resp.status} ${resp.statusText}`);
+      }
+
+      const data: FirebaseProjectI = await resp.json();
+
+      // Update project state and DOM only if data is valid
+      if (data?.name || data?.logo) {
+        setProjectInfo(data);
+        setProjectInfoInDOM(data.name, data.logo);
+      }
+    } catch (error) {
+      console.error("Error fetching project data:", error);
+    }
+  };
+
+  useEffect(() => {
+    const slug = pathname.replace(/\//g, "");
+
+    // Ensure we have a valid project name before making the request
+    if (slug) {
+      getProjectData(slug);
+    }
+  }, [pathname]); // Re-run when pathname changes
+
+  return projectInfo; // Return project info to be used in components
+};
+
+export default useProjectInfo;

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,13 +1,18 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import {BrowserRouter, Route, Routes} from "react-router-dom";
 import "./index.css";
 import App from "./App";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <Routes>
+        <Route
+          path="*"
+          element={<App />}
+        />
+      </Routes>
     </BrowserRouter>
   </StrictMode>,
 );

--- a/app/src/types/project.ts
+++ b/app/src/types/project.ts
@@ -1,0 +1,12 @@
+export interface FirebaseProjectI {
+  id: string
+  name: string
+  projectName: string
+  subdomain: string
+  userId: string
+  category: string
+  variant: string
+  twitter?: string
+  logo?: string
+  banner?: string
+}


### PR DESCRIPTION
Introduced `useProjectInfo` to fetch and manage project details dynamically, including setting the document title and favicon based on project data. Refactored `App` to use this hook, replacing hardcoded environment variables. Also updated routing to support new project-based behavior.